### PR TITLE
feat: Use micromamba for smaller footprint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,14 +12,14 @@ COPY requirements.lock /docker/requirements.lock
 COPY requirements.txt /docker/requirements.txt
 
 RUN apt-get update && \
+    apt-get install -yq \
+        curl && \
     apt-get install -yq --no-install-recommends \
         make \
         cmake \
         git \
         bzip2 \
         libarchive-dev && \
-    apt-get install -yq \
-        curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     curl -sL micro.mamba.pm/install.sh | bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,10 +13,12 @@ COPY requirements.txt /docker/requirements.txt
 
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
+        make \
+        cmake \
+        git \
         bzip2 \
         libarchive-dev && \
     apt-get install -yq \
-        git \
         curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,9 @@ COPY requirements.txt /docker/requirements.txt
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
         curl \
-        bzip2 \
         libarchive-dev && \
+    apt-get install -yq \
+        bzip2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     curl -sL micro.mamba.pm/install.sh | bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM condaforge/mambaforge:4.11.0-0 as base
+FROM debian:bullseye-slim as base
 # FROM coffeateam/coffea-dask:0.7.19-fastjet-3.3.4.0rc9-ge92ece7 as base
 
 SHELL [ "/bin/bash", "-c" ]
@@ -6,33 +6,37 @@ SHELL [ "/bin/bash", "-c" ]
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV TZ="Etc/UTC"
 
-RUN apt-get update && \
-    apt-get install -yq --no-install-recommends libarchive-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 COPY environment.yml /docker/environment.yml
 COPY full.conda-lock.yml /docker/conda-lock.yml
 COPY requirements.lock /docker/requirements.lock
 COPY requirements.txt /docker/requirements.txt
 
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends \
+        curl \
+        bzip2 \
+        libarchive-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -sL micro.mamba.pm/install.sh | bash
+
 # Need to manually source conda.sh for some reason, as `. /root/.bashrc` doesn't work?
-RUN . /opt/conda/etc/profile.d/conda.sh && \
-    mamba create --name lock && \
-    conda activate lock && \
-    mamba env list && \
-    mamba install --yes conda-lock && \
+RUN . /root/micromamba/etc/profile.d/micromamba.sh && \
+    micromamba create --name lock && \
+    micromamba activate lock && \
+    micromamba env list && \
+    micromamba install --channel conda-forge --yes conda-lock && \
     conda-lock install --help && \
     conda-lock install \
-        --mamba \
+        --micromamba \
         --name analysis-systems \
         /docker/conda-lock.yml && \
-    mamba clean --yes --all && \
-    sed -i 's/conda activate base/conda activate analysis-systems/g' /root/.bashrc && \
+    micromamba clean --yes --all && \
+    echo "micromamba activate analysis-systems" >> /root/.bashrc && \
     conda activate analysis-systems && \
-    conda env remove --name lock && \
-    mamba env list && \
-    mamba clean --yes --all && \
+    rm -rf /root/micromamba/envs/lock && \
+    micromamba env list && \
+    micromamba clean --yes --all && \
     python -m pip --no-cache-dir install --upgrade pip && \
     python -m pip --no-cache-dir install \
         --no-deps \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,7 +70,5 @@ RUN . /root/.bashrc && \
 #         torch-cluster \
 #         torch-spline-conv
 
-# Make images Singularity compatible
-# Make a symbolic link between installation /opt/conda/etc/grid-security and actual directory /etc/grid-security
-RUN mkdir -p /opt/conda && \
-    ln --symbolic /opt/conda/etc/grid-security /etc/grid-security
+# Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
+RUN ln --symbolic /root/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,7 @@ RUN . /root/.bashrc && \
         --name analysis-systems \
         /docker/conda-lock.yml && \
     micromamba clean --yes --all && \
+    echo 'export  PATH="/opt/micromamba/bin:${PATH}"' >> /root/.bashrc && \
     echo "micromamba activate analysis-systems" >> /root/.bashrc && \
     micromamba activate analysis-systems && \
     rm -rf /root/micromamba/envs/lock && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,4 +71,5 @@ RUN . /root/.bashrc && \
 #         torch-spline-conv
 
 # Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
-RUN ln --symbolic /root/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security
+RUN ln --symbolic /root/micromamba /opt/micromamba && \
+    ln --symbolic /root/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
         bzip2 \
         libarchive-dev && \
     apt-get install -yq \
+        git \
         curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,16 +13,15 @@ COPY requirements.txt /docker/requirements.txt
 
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
-        curl \
+        bzip2 \
         libarchive-dev && \
     apt-get install -yq \
-        bzip2 && \
+        curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     curl -sL micro.mamba.pm/install.sh | bash
 
-# Need to manually source conda.sh for some reason, as `. /root/.bashrc` doesn't work?
-RUN . /root/micromamba/etc/profile.d/micromamba.sh && \
+RUN . /root/.bashrc && \
     micromamba create --name lock && \
     micromamba activate lock && \
     micromamba env list && \
@@ -34,11 +33,11 @@ RUN . /root/micromamba/etc/profile.d/micromamba.sh && \
         /docker/conda-lock.yml && \
     micromamba clean --yes --all && \
     echo "micromamba activate analysis-systems" >> /root/.bashrc && \
-    conda activate analysis-systems && \
+    micromamba activate analysis-systems && \
     rm -rf /root/micromamba/envs/lock && \
     micromamba env list && \
     micromamba clean --yes --all && \
-    python -m pip --no-cache-dir install --upgrade pip && \
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install \
         --no-deps \
         --require-hashes \

--- a/noxfile.py
+++ b/noxfile.py
@@ -104,3 +104,13 @@ def publish(session):
             f"hub.opensciencegrid.org/iris-hep/analysis-systems-base:{tag}",
             external=True,
         )
+
+
+@nox.session()
+def deploy(session):
+    """
+    Build, tag, and push to registry
+    """
+    session.notify("build")
+    session.notify("tag")
+    session.notify("publish")

--- a/noxfile.py
+++ b/noxfile.py
@@ -104,13 +104,3 @@ def publish(session):
             f"hub.opensciencegrid.org/iris-hep/analysis-systems-base:{tag}",
             external=True,
         )
-
-
-@nox.session()
-def deploy(session):
-    """
-    Build, tag, and push to registry
-    """
-    session.notify("build")
-    session.notify("tag")
-    session.notify("publish")

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,6 +62,7 @@ def build(session):
     Build image
     """
     current_date = datetime.now().strftime("%Y-%m-%d")
+    session.run("docker", "pull", "debian:bullseye-slim", external=True)
     session.run(
         "docker",
         "build",


### PR DESCRIPTION
```
* Use micromamba for smaller image footprint.
* Use debian:bullseye-slim for smaller base image and to avoid existing mamba install.
* Pull base image as part of nox 'build' session.
```