### PR TITLE
feat: Use centos:centos7 as base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,9 +14,8 @@ RUN yum install -y \
       bzip2  && \
     yum clean all && \
     yum autoremove -y && \
-    curl -sL micro.mamba.pm/install.sh | bash
-
-RUN . /root/.bashrc && \
+    curl -sL micro.mamba.pm/install.sh | bash && \
+    . /root/.bashrc && \
     micromamba create --name lock && \
     micromamba activate lock && \
     micromamba env list && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,18 +10,8 @@ COPY full.conda-lock.yml /docker/conda-lock.yml
 COPY requirements.lock /docker/requirements.lock
 COPY requirements.txt /docker/requirements.txt
 
-RUN yum update -y && \
-    yum install -y \
-      gcc \
-      gcc-c++ \
-      gcc-gfortran \
-      make \
-      zlib \
-      zlib-devel \
-      bzip2 \
-      bzip2-devel \
-      rsync \
-      git && \
+RUN yum install -y \
+      bzip2  && \
     yum clean all && \
     yum autoremove -y && \
     curl -sL micro.mamba.pm/install.sh | bash
@@ -42,6 +32,12 @@ RUN . /root/.bashrc && \
     micromamba activate analysis-systems && \
     rm -rf /root/micromamba/envs/lock && \
     micromamba env list && \
+    micromamba install \
+        --channel conda-forge \
+        --yes \
+            cmake \
+            gcc \
+            git  && \
     micromamba clean --yes --all && \
     python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip --no-cache-dir install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,8 @@
-FROM debian:bullseye-slim as base
+FROM centos:centos7 as base
 # FROM coffeateam/coffea-dask:0.7.19-fastjet-3.3.4.0rc9-ge92ece7 as base
 
 SHELL [ "/bin/bash", "-c" ]
 
-ENV DEBIAN_FRONTEND="noninteractive"
 ENV TZ="Etc/UTC"
 
 COPY environment.yml /docker/environment.yml
@@ -11,17 +10,20 @@ COPY full.conda-lock.yml /docker/conda-lock.yml
 COPY requirements.lock /docker/requirements.lock
 COPY requirements.txt /docker/requirements.txt
 
-RUN apt-get update && \
-    apt-get install -yq \
-        curl && \
-    apt-get install -yq --no-install-recommends \
-        make \
-        cmake \
-        git \
-        bzip2 \
-        libarchive-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN yum update -y && \
+    yum install -y \
+      gcc \
+      gcc-c++ \
+      gcc-gfortran \
+      make \
+      zlib \
+      zlib-devel \
+      bzip2 \
+      bzip2-devel \
+      rsync \
+      git && \
+    yum clean all && \
+    yum autoremove -y && \
     curl -sL micro.mamba.pm/install.sh | bash
 
 RUN . /root/.bashrc && \

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,7 +62,7 @@ def build(session):
     Build image
     """
     current_date = datetime.now().strftime("%Y-%m-%d")
-    session.run("docker", "pull", "debian:bullseye-slim", external=True)
+    session.run("docker", "pull", "centos:centos7", external=True)
     session.run(
         "docker",
         "build",


### PR DESCRIPTION
```
* Use centos:centos7 as the base image as most HEP specific packages are well
  supported there (e.g. xrootd, condor, voms).
   - This does increase the image size to over 5 GB, which isn't great, but hopefully
     is worth it.
```