### PR TITLE
fix: Use /opt installs to avoid non-root user problems

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,6 +77,7 @@ RUN yum install -y \
 # Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
 # Ensure ENTRYPOINT is executable
 RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security && \
+    sed -i '1s|^|#!/bin/bash\n|' /etc/.bashrc && \
     chmod +x /etc/.bashrc
 
 ENTRYPOINT [ "/etc/.bashrc" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,7 @@ RUN yum install -y \
     yum autoremove -y && \
     curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin/ --strip-components=1 bin/micromamba && \
     /usr/local/bin/micromamba shell init -p /opt/micromamba && \
-    cp /root/.bashrc /etc/.bashrc && \
-    . /etc/.bashrc && \
+    . /root/.bashrc && \
     micromamba create --name lock && \
     micromamba activate lock && \
     micromamba env list && \
@@ -30,7 +29,8 @@ RUN yum install -y \
     micromamba clean --yes --all && \
     echo 'export  PATH="/opt/micromamba/bin:${PATH}"' >> /root/.bashrc && \
     echo "micromamba activate analysis-systems" >> /root/.bashrc && \
-    cp /root/.bashrc /etc/.bashrc && \
+    cp /root/.bashrc /etc/bashrc && \
+    cat /root/.bashrc >> /etc/profile && \
     micromamba activate analysis-systems && \
     rm -rf /opt/micromamba/envs/lock && \
     micromamba env list && \
@@ -74,7 +74,8 @@ RUN yum install -y \
 #         torch-cluster \
 #         torch-spline-conv
 
-COPY entrypoint.sh /docker/entrypoint.sh
 # Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
-RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security && \
-    chmod +x /docker/entrypoint.sh
+RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security
+
+# Run with login shell to trigger /etc/profile
+ENTRYPOINT ["/bin/bash", "-l"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,4 +81,5 @@ RUN yum install -y \
 RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security
 
 # Run with login shell to trigger /etc/profile
+# c.f. https://youngstone89.medium.com/unix-introduction-bash-startup-files-loading-order-562543ac12e9
 ENTRYPOINT ["/bin/bash", "-l"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,10 @@ RUN yum install -y \
       bzip2  && \
     yum clean all && \
     yum autoremove -y && \
-    curl -sL micro.mamba.pm/install.sh | bash && \
-    . /root/.bashrc && \
+    curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin/ --strip-components=1 bin/micromamba && \
+    /usr/local/bin/micromamba shell init -p /opt/micromamba && \
+    cp /root/.bashrc /etc/.bashrc && \
+    . /etc/.bashrc && \
     micromamba create --name lock && \
     micromamba activate lock && \
     micromamba env list && \
@@ -28,8 +30,9 @@ RUN yum install -y \
     micromamba clean --yes --all && \
     echo 'export  PATH="/opt/micromamba/bin:${PATH}"' >> /root/.bashrc && \
     echo "micromamba activate analysis-systems" >> /root/.bashrc && \
+    cp /root/.bashrc /etc/.bashrc && \
     micromamba activate analysis-systems && \
-    rm -rf /root/micromamba/envs/lock && \
+    rm -rf /opt/micromamba/envs/lock && \
     micromamba env list && \
     micromamba install \
         --channel conda-forge \
@@ -72,5 +75,8 @@ RUN yum install -y \
 #         torch-spline-conv
 
 # Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
-RUN ln --symbolic /root/micromamba /opt/micromamba && \
-    ln --symbolic /root/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security
+# Ensure ENTRYPOINT is executable
+RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security && \
+    chmod +x /etc/.bashrc
+
+ENTRYPOINT [ "/etc/.bashrc" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,10 +74,7 @@ RUN yum install -y \
 #         torch-cluster \
 #         torch-spline-conv
 
+COPY entrypoint.sh /docker/entrypoint.sh
 # Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
-# Ensure ENTRYPOINT is executable
 RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security && \
-    sed -i '1s|^|#!/bin/bash\n|' /etc/.bashrc && \
-    chmod +x /etc/.bashrc
-
-ENTRYPOINT [ "/etc/.bashrc" ]
+    chmod +x /docker/entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,9 +14,13 @@ RUN yum install -y \
       bzip2  && \
     yum clean all && \
     yum autoremove -y && \
+    cp /root/.bashrc /etc/.bashrc.bak && \
     curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin/ --strip-components=1 bin/micromamba && \
-    /usr/local/bin/micromamba shell init -p /opt/micromamba && \
-    . /root/.bashrc && \
+    micromamba shell init --prefix /opt/micromamba --shell bash && \
+    /usr/local/bin/micromamba shell init --prefix /opt/micromamba && \
+    diff /root/.bashrc /etc/.bashrc.bak | grep "< " | cut -c 3- >> /etc/.bashrc && \
+    mv /etc/.bashrc.bak /root/.bashrc && \
+    . /etc/.bashrc && \
     micromamba create --name lock && \
     micromamba activate lock && \
     micromamba env list && \
@@ -27,10 +31,10 @@ RUN yum install -y \
         --name analysis-systems \
         /docker/conda-lock.yml && \
     micromamba clean --yes --all && \
-    echo 'export  PATH="/opt/micromamba/bin:${PATH}"' >> /root/.bashrc && \
-    echo "micromamba activate analysis-systems" >> /root/.bashrc && \
-    cp /root/.bashrc /etc/bashrc && \
-    cat /root/.bashrc >> /etc/profile && \
+    echo 'export  PATH="/opt/micromamba/bin:${PATH}"' >> /etc/.bashrc && \
+    echo "micromamba activate analysis-systems" >> /etc/.bashrc && \
+    echo 'if [ -f /etc/.bashrc ]; then . /etc/.bashrc; fi' >> /etc/profile && \
+    . /etc/.bashrc && \
     micromamba activate analysis-systems && \
     rm -rf /opt/micromamba/envs/lock && \
     micromamba env list && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,12 +14,10 @@ RUN yum install -y \
       bzip2  && \
     yum clean all && \
     yum autoremove -y && \
-    cp /root/.bashrc /etc/.bashrc.bak && \
     curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj -C /usr/local/bin/ --strip-components=1 bin/micromamba && \
     micromamba shell init --prefix /opt/micromamba --shell bash && \
     /usr/local/bin/micromamba shell init --prefix /opt/micromamba && \
-    diff /root/.bashrc /etc/.bashrc.bak | grep "< " | cut -c 3- >> /etc/.bashrc && \
-    mv /etc/.bashrc.bak /root/.bashrc && \
+    cp /root/.bashrc /etc/.bashrc && \
     . /etc/.bashrc && \
     micromamba create --name lock && \
     micromamba activate lock && \
@@ -57,7 +55,8 @@ RUN yum install -y \
         torch-scatter \
         torch-sparse \
         torch-cluster \
-        torch-spline-conv
+        torch-spline-conv && \
+    rm -rf /root/*
 
 # If need to split into two stages for debugging
 # RUN . /opt/conda/etc/profile.d/conda.sh && \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+. /etc/.bashrc
+
+# # Run CMD
+# /bin/bash "$@"
+
+echo "$@"
+exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-. /etc/.bashrc
-
-# # Run CMD
-# /bin/bash "$@"
-
-echo "$@"
-exec "$@"


### PR DESCRIPTION
Install micromamba such that the `micromamba` executable is at `/usr/local/bin/micromamba` and `MAMBA_ROOT_PREFIX` is `/opt/micromamba`. Additionally, try to make it so that _all_ users will have `/etc/.bashrc` run so that all users will have the `analysis-systems` `micromamba` environment activated at login.

At the moment in this PR there is a problem with two different states depending on if user is root or not:

* user is root:

```console
$ docker run --rm -ti hub.opensciencegrid.org/iris-hep/analysis-systems-base:2022-11-01 
(analysis-systems) [root@a73bc5b6f9a2 /]# micromamba env list

                                           __
          __  ______ ___  ____ _____ ___  / /_  ____ _
         / / / / __ `__ \/ __ `/ __ `__ \/ __ \/ __ `/
        / /_/ / / / / / / /_/ / / / / / / /_/ / /_/ /
       / .___/_/ /_/ /_/\__,_/_/ /_/ /_/_.___/\__,_/
      /_/

  Name              Active  Path                                 
───────────────────────────────────────────────────────────────────
  base                      /opt/micromamba                      
  analysis-systems  *       /opt/micromamba/envs/analysis-systems
(analysis-systems) [root@a73bc5b6f9a2 /]# 
```

* user is arbitrary and non-root

```console
$ docker run --rm -ti --user $(id -u $USER):$(id -g) hub.opensciencegrid.org/iris-hep/analysis-systems-base:2022-11-01 
bash-4.2$ . /etc/.bashrc 
bash: history: //.bash_history: cannot create: Permission denied
/usr/bin/id: cannot find name for group ID 1000
/usr/bin/id: cannot find name for user ID 1000
(analysis-systems) [I have no name!@dad4547f63a3 /]$ micromamba env list

                                           __
          __  ______ ___  ____ _____ ___  / /_  ____ _
         / / / / __ `__ \/ __ `/ __ `__ \/ __ \/ __ `/
        / /_/ / / / / / / /_/ / / / / / / /_/ / /_/ /
       / .___/_/ /_/ /_/\__,_/_/ /_/ /_/_.___/\__,_/
      /_/

  Name              Active  Path                                 
───────────────────────────────────────────────────────────────────
  base                      /opt/micromamba                      
  analysis-systems  *       /opt/micromamba/envs/analysis-systems
(analysis-systems) [I have no name!@dad4547f63a3 /]$
```

Fixed for now!

```
* Install micromamba such that micromamba executable is at
  /usr/local/bin/micromamba and MAMBA_ROOT_PREFIX is /opt/micromamba.
* Place all configuration in /etc/.bashrc which is sourced from /etc/profile
  which is enforced by having ENTRYPOINT use a login shell. This should harmonize
  the user experience between root and non-root users.
   - c.f. https://youngstone89.medium.com/unix-introduction-bash-startup-files-loading-order-562543ac12e9
* Remove all files under /root/ to prevent other accidental issues that cause things
  to work as root but not as non-root users.

Co-authored-by: Yuvi Panda <yuvipanda@gmail.com>
```