### PR TITLE
feat: Add Analysis Systems kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,23 @@ docker run \
     hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest
 ```
 
-and then when inside run Jupyter Lab with corresponding options
+which will then launch Jupyter Lab with corresponding option defaults
 
 ```
 jupyter lab --no-browser --ip 0.0.0.0 --port 8888
+```
+
+#### Running without the defaults
+
+If you just want an interactive shell or need to run with different options then pass in `--` as the `CMD`:
+
+```
+docker run \
+    --rm \
+    -ti \
+    --publish 8888:8888 \
+    --user $(id -u $USER):$(id -g) \
+    hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest --
 ```
 
 ### Running as root

--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ docker run \
     --rm \
     -ti \
     --publish 8888:8888 \
-    hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest
+    hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest --
 ```

--- a/README.md
+++ b/README.md
@@ -9,14 +9,33 @@ docker pull hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest
 
 ## Usage
 
-### Running as root
-
-```
-docker run --rm -ti -p 8888:8888 hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest
-```
-
 ### Running as non-root user
 
+Run the container with configuration options
+
 ```
-docker run --rm -ti -p 8888:8888 --user $(id -u $USER):$(id -g) hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest
+docker run \
+    --rm \
+    -ti \
+    --publish 8888:8888 \
+    --user $(id -u $USER):$(id -g) \
+    hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest
+```
+
+and then when inside run Jupyter Lab with corresponding options
+
+```
+jupyter lab --no-browser --ip 0.0.0.0 --port 8888
+```
+
+### Running as root
+
+(Not recommended)
+
+```
+docker run \
+    --rm \
+    -ti \
+    --publish 8888:8888 \
+    hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest
 ```

--- a/README.md
+++ b/README.md
@@ -6,3 +6,17 @@ Base Docker image for Analysis Systems environment
 ```
 docker pull hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest
 ```
+
+## Usage
+
+### Running as root
+
+```
+docker run --rm -ti -p 8888:8888 hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest
+```
+
+### Running as non-root user
+
+```
+docker run --rm -ti -p 8888:8888 --user $(id -u $USER):$(id -g) hub.opensciencegrid.org/iris-hep/analysis-systems-base:latest
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,7 +89,15 @@ RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/g
     ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels/analysis-systems /u0b/software/jupyter/kernels/analysis-systems && \
     mkdir -p /.local && \
     chmod 777 /.local && \
+    mkdir -p /.jupyter && \
+    chmod 777 /.jupyter && \
+    mkdir -p /.config && \
+    chmod 777 /.config && \
+    mkdir -p /work && \
+    chmod 777 /work && \
     echo "# image build date: $(date)" > /docker/build_date.txt
+
+WORKDIR /work
 
 # Run with login shell to trigger /etc/profile
 # c.f. https://youngstone89.medium.com/unix-introduction-bash-startup-files-loading-order-562543ac12e9

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,6 +87,8 @@ RUN yum install -y \
 RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security && \
     mkdir -p /u0b/software/jupyter/kernels && \
     ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels/analysis-systems /u0b/software/jupyter/kernels/analysis-systems && \
+    mkdir -p /.local && \
+    chmod 777 /.local && \
     echo "# image build date: $(date)" > /docker/build_date.txt
 
 # Run with login shell to trigger /etc/profile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,20 +83,25 @@ RUN yum install -y \
 
 # * Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
 # * Make "analysis-systems" kernel discoverable to BNL SDCC which has kenerls at /u0b/software/jupyter/kernels/
+# * Ensure default directories and that they are writeable by arbitrary user
+# * Set defaults for jupyter lab
+# * Set JUPYTER_PATH and JUPYTER_DATA_DIR
 # * Add build date file to easily check if analysis facilities have synced images
 RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security && \
     mkdir -p /u0b/software/jupyter/kernels && \
     ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels/analysis-systems /u0b/software/jupyter/kernels/analysis-systems && \
-    mkdir -p /.local && \
-    chmod 777 /.local && \
-    mkdir -p /.jupyter && \
-    chmod 777 /.jupyter && \
-    mkdir -p /.config && \
-    chmod 777 /.config && \
-    mkdir -p /.cache && \
-    chmod 777 /.cache && \
-    mkdir -p /work && \
-    chmod 777 /work && \
+    mkdir -p \
+        /.local \
+        /.jupyter \
+        /.config \
+        /.cache \
+        /work && \
+    chmod 777 \
+        /.local \
+        /.jupyter \
+        /.config \
+        /.cache \
+        /work && \
     printf '#!/bin/bash\n\njupyter lab --no-browser --ip 0.0.0.0 --port 8888\n' > /docker/entrypoint.sh && \
     chmod 777 /docker/entrypoint.sh && \
     echo 'export JUPYTER_PATH="/opt/micromamba/envs/analysis-systems/share/jupyter:${JUPYTER_PATH}"' >> /etc/.bashrc && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,6 +84,10 @@ RUN yum install -y \
 # Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
 RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security
 
+# Make "analysis-systems" kernel discoverable to BNL SDCC which has kenerls at /u0b/software/jupyter/kernels/
+RUN mkdir -p /u0b/software/jupyter && \
+    ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels /u0b/software/jupyter/kernels
+
 # Run with login shell to trigger /etc/profile
 # c.f. https://youngstone89.medium.com/unix-introduction-bash-startup-files-loading-order-562543ac12e9
 ENTRYPOINT ["/bin/bash", "-l"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -99,6 +99,7 @@ RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/g
     chmod 777 /work && \
     printf '#!/bin/bash\n\njupyter lab --no-browser --ip 0.0.0.0 --port 8888\n' > /docker/entrypoint.sh && \
     chmod 777 /docker/entrypoint.sh && \
+    echo 'export JUPYTER_PATH="/opt/micromamba/envs/analysis-systems/share/jupyter:${JUPYTER_PATH}"' >> /etc/.bashrc && \
     echo "# image build date: $(date)" > /docker/build_date.txt
 
 WORKDIR /work

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -106,3 +106,5 @@ WORKDIR /work
 # Run with login shell to trigger /etc/profile
 # c.f. https://youngstone89.medium.com/unix-introduction-bash-startup-files-loading-order-562543ac12e9
 ENTRYPOINT ["/bin/bash", "-l"]
+
+CMD ["/docker/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,6 +93,8 @@ RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/g
     chmod 777 /.jupyter && \
     mkdir -p /.config && \
     chmod 777 /.config && \
+    mkdir -p /.cache && \
+    chmod 777 /.cache && \
     mkdir -p /work && \
     chmod 777 /work && \
     echo "# image build date: $(date)" > /docker/build_date.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,12 +81,13 @@ RUN yum install -y \
 #         torch-cluster \
 #         torch-spline-conv
 
-# Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
-RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security
-
-# Make "analysis-systems" kernel discoverable to BNL SDCC which has kenerls at /u0b/software/jupyter/kernels/
-RUN mkdir -p /u0b/software/jupyter/kernels && \
-    ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels/analysis-systems /u0b/software/jupyter/kernels/analysis-systems
+# * Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
+# * Make "analysis-systems" kernel discoverable to BNL SDCC which has kenerls at /u0b/software/jupyter/kernels/
+# * Add build date file to easily check if analysis facilities have synced images
+RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security && \
+    mkdir -p /u0b/software/jupyter/kernels && \
+    ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels/analysis-systems /u0b/software/jupyter/kernels/analysis-systems && \
+    echo "# image build date: $(date)" > /docker/build_date.txt
 
 # Run with login shell to trigger /etc/profile
 # c.f. https://youngstone89.medium.com/unix-introduction-bash-startup-files-loading-order-562543ac12e9

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,7 +100,8 @@ RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/g
     printf '#!/bin/bash\n\njupyter lab --no-browser --ip 0.0.0.0 --port 8888\n' > /docker/entrypoint.sh && \
     chmod 777 /docker/entrypoint.sh && \
     echo 'export JUPYTER_PATH="/opt/micromamba/envs/analysis-systems/share/jupyter:${JUPYTER_PATH}"' >> /etc/.bashrc && \
-    echo 'export JUPYTER_DATA_DIR="/opt/micromamba/envs/analysis-systems/share/jupyter:${JUPYTER_DATA_DIR}"' >> /etc/.bashrc && \
+    echo 'export JUPYTER_DATA_DIR="/opt/micromamba/envs/analysis-systems/share/jupyter"' >> /etc/.bashrc && \
+    chmod 777 /opt/micromamba/envs/analysis-systems/share/jupyter && \
     echo "# image build date: $(date)" > /docker/build_date.txt
 
 WORKDIR /work

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,6 +56,10 @@ RUN yum install -y \
         torch-sparse \
         torch-cluster \
         torch-spline-conv && \
+    python -m ipykernel install \
+        --name="analysis-systems" \
+        --display-name="Analysis Systems" \
+        --sys-prefix && \
     rm -rf /root/*
 
 # If need to split into two stages for debugging

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,6 +97,8 @@ RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/g
     chmod 777 /.cache && \
     mkdir -p /work && \
     chmod 777 /work && \
+    printf '#!/bin/bash\n\njupyter lab --no-browser --ip 0.0.0.0 --port 8888\n' > /docker/entrypoint.sh && \
+    chmod 777 /docker/entrypoint.sh && \
     echo "# image build date: $(date)" > /docker/build_date.txt
 
 WORKDIR /work

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,8 +85,8 @@ RUN yum install -y \
 RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security
 
 # Make "analysis-systems" kernel discoverable to BNL SDCC which has kenerls at /u0b/software/jupyter/kernels/
-RUN mkdir -p /u0b/software/jupyter && \
-    ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels /u0b/software/jupyter/kernels
+RUN mkdir -p /u0b/software/jupyter/kernels && \
+    ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels/analysis-systems /u0b/software/jupyter/kernels/analysis-systems
 
 # Run with login shell to trigger /etc/profile
 # c.f. https://youngstone89.medium.com/unix-introduction-bash-startup-files-loading-order-562543ac12e9

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,6 +102,8 @@ RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/g
     echo "# image build date: $(date)" > /docker/build_date.txt
 
 WORKDIR /work
+# Ensure HOME exists and that it is writeable
+ENV HOME=/work
 
 # Run with login shell to trigger /etc/profile
 # c.f. https://youngstone89.medium.com/unix-introduction-bash-startup-files-loading-order-562543ac12e9

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,6 +100,7 @@ RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/g
     printf '#!/bin/bash\n\njupyter lab --no-browser --ip 0.0.0.0 --port 8888\n' > /docker/entrypoint.sh && \
     chmod 777 /docker/entrypoint.sh && \
     echo 'export JUPYTER_PATH="/opt/micromamba/envs/analysis-systems/share/jupyter:${JUPYTER_PATH}"' >> /etc/.bashrc && \
+    echo 'export JUPYTER_DATA_DIR="/opt/micromamba/envs/analysis-systems/share/jupyter:${JUPYTER_DATA_DIR}"' >> /etc/.bashrc && \
     echo "# image build date: $(date)" > /docker/build_date.txt
 
 WORKDIR /work


### PR DESCRIPTION
* Add Analysis Systems kernel.
* Set CMD to launch Jupyter Lab with defaults: `jupyter lab --no-browser --ip 0.0.0.0 --port 8888`
* Set `JUPYTER_PATH` and `JUPYTER_DATA_DIR` to attempt to ensure that kernel is visible in Launcher at BNL SDCC Jupyter test infrastructure. This is still not working as of 2022-11-02.
   - c.f. https://atlas-talk.sdcc.bnl.gov/t/how-to-activate-python-virtual-environments-with-custom-images/269
* Add `/docker/build_date.txt` to have easy reference for developers to check if deployment sync through CVMFS unpacked sync has completed.
* Add basic usage instructions to the README.