### PR TITLE
feat: Add nodejs for jupyterlab extensions support

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -39,6 +39,9 @@ dependencies:
   # coffea[servicex] components available on conda-forge
   - aiostream
   - tenacity
+  # Jupyter Lab extensions
+  - nodejs
+  - jupyterlab-github
   # IRIS-HEP Analysis Systems
   - awkward ==1.10.1
   - uproot ==4.3.7

--- a/docker/full.conda-lock.yml
+++ b/docker/full.conda-lock.yml
@@ -15,7 +15,7 @@ metadata:
   - url: conda-forge
     used_env_vars: []
   content_hash:
-    linux-64: 9fabb302156854e48e167bc744373e19267f98a36c512edb65992080ed560d84
+    linux-64: 2eb8b5bcb5e86e5e44580a50a3693466ecc844721b9021d2e1738ca322fee69a
   platforms:
   - linux-64
   sources:
@@ -1682,6 +1682,25 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.31-h28c427c_0.tar.bz2
   version: 8.0.31
+- category: main
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=70.1,<71.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libuv: '>=1.44.2,<1.45.0a0'
+    libzlib: '>=1.2.12,<1.3.0a0'
+    openssl: '>=1.1.1q,<1.1.2a'
+    zlib: ''
+  hash:
+    md5: 1a98de19be456d005a8ca0d64a073ad7
+    sha256: 5783f52a6da4036fdbbb3e15ab9a15795454ab298bf8b90b53295863c2f24002
+  manager: conda
+  name: nodejs
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-18.11.0-h96d913c_0.tar.bz2
+  version: 18.11.0
 - category: main
   dependencies:
     libgcc-ng: '>=12'
@@ -5527,6 +5546,20 @@ package:
   platform: linux-64
   url: https://conda.anaconda.org/conda-forge/noarch/dask-labextension-6.0.0-pyhd8ed1ab_0.tar.bz2
   version: 6.0.0
+- category: main
+  dependencies:
+    jupyterlab: '>=3.0,<4'
+    notebook: <7
+    python: '>=3.6'
+  hash:
+    md5: 2c7f4ea067ac22a2d2aa854490eff654
+    sha256: 3dc8d10ce30ab1204479d1f7df9d221005f8605cfb1a64de6825d229380a29ca
+  manager: conda
+  name: jupyterlab-github
+  optional: false
+  platform: linux-64
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-github-3.0.1-pyhd8ed1ab_0.tar.bz2
+  version: 3.0.1
 - category: main
   dependencies:
     dask-labextension: '>=6.0.0,<6.0.1.0a0'


### PR DESCRIPTION
```
* Add nodejs and jupyterlab-github to environment.yml and rebuild
  conda-lock lock file.
```