### PR TITLE
chore: Use '--use-pep517' pip flag for sdist builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,6 +50,7 @@ RUN yum install -y \
         --require-hashes \
         --only-binary :all: \
         --no-binary torch-geometric \
+        --use-pep517 \
         --requirement /docker/requirements.lock && \
     python -m pip --no-cache-dir install \
         --find-links https://data.pyg.org/whl/torch-1.12.1+cpu.html \


### PR DESCRIPTION
* Avoids warning of:
> DEPRECATION: torch-geometric is being installed using the legacy 'setup.py install' method, because the '--no-binary' option was enabled for it and this currently disables local wheel building for projects that don't have a 'pyproject.toml' file. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option.