### PR TITLE
feat: Add HTCondor v9 and BNL mount points

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,7 +128,7 @@ ENV HOME=/work
 RUN . /etc/.bashrc && \
     micromamba activate analysis-systems && \
     jupyter lab --generate-config && \
-    sed -i 's|# c.ServerApp.terminado_settings = {}|c.ServerApp.terminado_settings = { "shell_command": ["/usr/bin/bash"] }|g' "${HOME}/.jupyter/jupyter_lab_config.py" && \
+    sed -i 's|# c.ServerApp.terminado_settings = {}|c.ServerApp.terminado_settings = { "shell_command": ["/usr/bin/bash", "-l"] }|g' "${HOME}/.jupyter/jupyter_lab_config.py" && \
     ln --symbolic $(jupyter --config-dir) /usr/local/etc/jupyter && \
     chmod -R 777 /work
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,14 +124,6 @@ WORKDIR /work
 # Ensure HOME exists and that it is writeable
 ENV HOME=/work
 
-# Set Jupyter Lab defaults and make findable
-RUN . /etc/.bashrc && \
-    micromamba activate analysis-systems && \
-    jupyter lab --generate-config && \
-    sed -i 's|# c.ServerApp.terminado_settings = {}|c.ServerApp.terminado_settings = { "shell_command": ["/usr/bin/bash", "-l"] }|g' "${HOME}/.jupyter/jupyter_lab_config.py" && \
-    ln --symbolic $(jupyter --config-dir) /usr/local/etc/jupyter && \
-    chmod -R 777 /work
-
 # Run with login shell to trigger /etc/profile
 # c.f. https://youngstone89.medium.com/unix-introduction-bash-startup-files-loading-order-562543ac12e9
 ENTRYPOINT ["/bin/bash", "-l"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,6 +85,7 @@ RUN yum install -y \
 
 ARG HTCONDOR_VERSION=9.0
 # install condor v9
+# /etc/condor and /direct/condor are necessary bind mounts for BNL
 RUN mkdir -p -v /etc/condor && \
     mkdir -p -v /direct/condor && \
     yum install -y https://research.cs.wisc.edu/htcondor/repo/9.0/htcondor-release-current.el7.noarch.rpm && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,7 +107,7 @@ RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/g
         /.config \
         /.cache \
         /work && \
-    chmod 777 \
+    chmod -R 777 \
         /.local \
         /.jupyter \
         /.config \
@@ -124,11 +124,13 @@ WORKDIR /work
 # Ensure HOME exists and that it is writeable
 ENV HOME=/work
 
-# Set Jupyter Lab defaults
+# Set Jupyter Lab defaults and make findable
 RUN . /etc/.bashrc && \
     micromamba activate analysis-systems && \
     jupyter lab --generate-config && \
-    sed -i 's|# c.ServerApp.terminado_settings = {}|c.ServerApp.terminado_settings = { "shell_command": ["/usr/bin/bash"] }|g' "${HOME}/.jupyter/jupyter_lab_config.py"
+    sed -i 's|# c.ServerApp.terminado_settings = {}|c.ServerApp.terminado_settings = { "shell_command": ["/usr/bin/bash"] }|g' "${HOME}/.jupyter/jupyter_lab_config.py" && \
+    ln --symbolic $(jupyter --config-dir) /usr/local/etc/jupyter && \
+    chmod -R 777 /work
 
 # Run with login shell to trigger /etc/profile
 # c.f. https://youngstone89.medium.com/unix-introduction-bash-startup-files-loading-order-562543ac12e9

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,6 +83,15 @@ RUN yum install -y \
 #         torch-cluster \
 #         torch-spline-conv
 
+ARG HTCONDOR_VERSION=9.0
+# install condor v9
+RUN mkdir -p -v /etc/condor && \
+    mkdir -p -v /direct/condor && \
+    yum install -y https://research.cs.wisc.edu/htcondor/repo/9.0/htcondor-release-current.el7.noarch.rpm && \
+    yum install -y https://research.cs.wisc.edu/htcondor/repo/9.0/el7/x86_64/release/condor-9.0.17-1.el7.x86_64.rpm && \
+    yum clean all && \
+    yum autoremove -y
+
 # * Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
 # * Make "analysis-systems" kernel discoverable to BNL SDCC which has kenerls at /u0b/software/jupyter/kernels/
 # * Ensure default directories and that they are writeable by arbitrary user
@@ -90,9 +99,9 @@ RUN yum install -y \
 # * Set JUPYTER_PATH and JUPYTER_DATA_DIR
 # * Add build date file to easily check if analysis facilities have synced images
 RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security && \
-    mkdir -p /u0b/software/jupyter/kernels && \
+    mkdir -p -v /u0b/software/jupyter/kernels && \
     ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels/analysis-systems /u0b/software/jupyter/kernels/analysis-systems && \
-    mkdir -p \
+    mkdir -p -v \
         /.local \
         /.jupyter \
         /.config \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,7 +107,7 @@ RUN ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/g
         /.config \
         /.cache \
         /work && \
-    chmod -R 777 \
+    chmod 777 \
         /.local \
         /.jupyter \
         /.config \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,6 +124,12 @@ WORKDIR /work
 # Ensure HOME exists and that it is writeable
 ENV HOME=/work
 
+# Set Jupyter Lab defaults
+RUN . /etc/.bashrc && \
+    micromamba activate analysis-systems && \
+    jupyter lab --generate-config && \
+    sed -i 's|# c.ServerApp.terminado_settings = {}|c.ServerApp.terminado_settings = { "shell_command": ["/usr/bin/bash"] }|g' "${HOME}/.jupyter/jupyter_lab_config.py"
+
 # Run with login shell to trigger /etc/profile
 # c.f. https://youngstone89.medium.com/unix-introduction-bash-startup-files-loading-order-562543ac12e9
 ENTRYPOINT ["/bin/bash", "-l"]


### PR DESCRIPTION
To add HTCondor support at BNL and also enable Dask executors, add HTCondor v9 to the image and also create mount points of `/etc/condor` and `/direct/condor`. Here use the patch that Doug emailed me (I'll try to see if the `v9.X` versions on Conda-forge are viable later).

```
* Add HTCondor v9
* Add volume mount points of /etc/condor and /direct/condor to
  work with BNL's HTCondor setup.

Co-authored-by: Doug Benjamin <douglas.benjamin@cern.ch>
```