### PR TITLE
fix: Symlink condor to ensure available globally

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,10 +91,12 @@ RUN yum install -y \
 # * Set JUPYTER_PATH and JUPYTER_DATA_DIR
 # * Add build date file to easily check if analysis facilities have synced images
 # * Add bind mount to Lustre space at BNL SDCC
+# * Symlink condor binaries under /usr/bin/ to ensure available globally
 RUN mkdir -p -v /etc/condor && \
     mkdir -p -v /direct/condor && \
     mkdir -p -v /usatlas/atlas01 && \
     ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security && \
+    ln --symbolic "$(dirname $(command -v condor_q))"/condor_* /usr/bin/ && \
     mkdir -p -v /u0b/software/jupyter/kernels && \
     ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels/analysis-systems /u0b/software/jupyter/kernels/analysis-systems && \
     mkdir -p -v \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,6 +83,16 @@ RUN yum install -y \
 #         torch-cluster \
 #         torch-spline-conv
 
+ARG HTCONDOR_VERSION=9.0
+# install condor v9
+# /etc/condor and /direct/condor are necessary bind mounts for BNL
+RUN mkdir -p -v /etc/condor && \
+    mkdir -p -v /direct/condor && \
+    yum install -y https://research.cs.wisc.edu/htcondor/repo/9.0/htcondor-release-current.el7.noarch.rpm && \
+    yum install -y https://research.cs.wisc.edu/htcondor/repo/9.0/el7/x86_64/release/condor-9.0.17-1.el7.x86_64.rpm && \
+    yum clean all && \
+    yum autoremove -y
+
 # /etc/condor and /direct/condor are necessary bind mounts for BNL
 # * Make a symbolic link between installation <...>/etc/grid-security and actual directory /etc/grid-security
 # * Make "analysis-systems" kernel discoverable to BNL SDCC which has kenerls at /u0b/software/jupyter/kernels/
@@ -96,9 +106,6 @@ RUN mkdir -p -v /etc/condor && \
     mkdir -p -v /direct/condor && \
     mkdir -p -v /usatlas/atlas01 && \
     ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security && \
-    . /etc/.bashrc && \
-    micromamba activate analysis-systems && \
-    ln --symbolic "$(dirname $(command -v condor_q))"/condor_* /usr/bin/ && \
     mkdir -p -v /u0b/software/jupyter/kernels && \
     ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels/analysis-systems /u0b/software/jupyter/kernels/analysis-systems && \
     mkdir -p -v \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,6 +96,8 @@ RUN mkdir -p -v /etc/condor && \
     mkdir -p -v /direct/condor && \
     mkdir -p -v /usatlas/atlas01 && \
     ln --symbolic /opt/micromamba/envs/analysis-systems/etc/grid-security /etc/grid-security && \
+    . /etc/.bashrc && \
+    micromamba activate analysis-systems && \
     ln --symbolic "$(dirname $(command -v condor_q))"/condor_* /usr/bin/ && \
     mkdir -p -v /u0b/software/jupyter/kernels && \
     ln --symbolic /opt/micromamba/envs/analysis-systems/share/jupyter/kernels/analysis-systems /u0b/software/jupyter/kernels/analysis-systems && \


### PR DESCRIPTION
```
* To run on BNL it is currently required that HTCondor 9 is used.
  To ensure global availability symlink the installed HTCondor 9
  under /usr/bin/.
```